### PR TITLE
Enable AndroidX support

### DIFF
--- a/ChannelRemote_v2/ChannelRemote/gradle.properties
+++ b/ChannelRemote_v2/ChannelRemote/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- enable AndroidX in gradle.properties

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15fd0f3888328b488d3751b0d22fa